### PR TITLE
Fix CLI type annotations

### DIFF
--- a/memory_system/cli.py
+++ b/memory_system/cli.py
@@ -15,11 +15,14 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, Optional, Type, cast
 
 # ────────────────────────────── third-party imports ────────────────────────────
 import httpx
 import typer
+
+Panel: Type[Any]
+Table: Type[Any]
 
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- annotate Panel and Table for rich-less CLI mode

## Testing
- `ruff check memory_system/cli.py`
- `mypy memory_system/cli.py` *(fails: other modules missing typed bases)*

------
https://chatgpt.com/codex/tasks/task_e_686d45632e288325a13311516db113af