### PR TITLE
Install pytest asyncio plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,13 @@ Development & Testing
 # run unit + integration tests
 pytest -q
 
+If tests fail with ``async def functions are not natively supported`` install
+the ``pytest-asyncio`` plugin::
+
+   pip install pytest-asyncio>=1.0.0
+
+This allows ``pytest`` to run async tests without warnings.
+
 # build & start containerised dev stack
 docker compose up --build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dev = [
   "ruff>=0.4",
   "mypy>=1.10",
   "pytest>=8.2",
-  "pytest-asyncio>=0.23",
+  "pytest-asyncio>=1.0.0",
   "coverage>=7.5",
   "bandit>=1.7",
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@
 # Testing
 # pip install pytest-asyncio
 pytest>=7.4.0,<8.0.0
-pytest-asyncio>=0.21.0,<1.0.0
+pytest-asyncio>=1.0.0
 pytest-cov>=4.1.0,<5.0.0
 pytest-mock>=3.12.0,<4.0.0
 pytest-benchmark>=4.0.0,<5.0.0


### PR DESCRIPTION
## Summary
- require `pytest-asyncio>=1.0.0`
- document how to install the plugin

## Testing
- `pytest -q`
- `pip install pytest-asyncio==1.0.0` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_687278c1b35c83259f50c3344968328e